### PR TITLE
Fix freezing video.

### DIFF
--- a/public/sketch.js
+++ b/public/sketch.js
@@ -14,6 +14,7 @@ function setup() {
 }
 
 function draw() {
+  // Issue related to: https://github.com/processing/p5.js/issues/4535#issuecomment-640072884
   image(video.get(), 0, 0, width, height);
 
   for (let i = 0; i < detections.length; i++) {

--- a/public/sketch.js
+++ b/public/sketch.js
@@ -14,7 +14,7 @@ function setup() {
 }
 
 function draw() {
-  image(video, 0, 0, width, height);
+  image(video.get(), 0, 0, width, height);
 
   for (let i = 0; i < detections.length; i++) {
     let cube = detections[i];


### PR DESCRIPTION
Problem is also mentioned here https://github.com/processing/p5.js/issues/4535#issuecomment-640072884

When there is a canvas source on the video, stream freezes. using get to draw an image fixes this issue.

Also saw this usage in docs https://p5js.org/reference/#/p5/createCapture where image.get is used before drawing the capture.

